### PR TITLE
Fix missing security rule

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,3 +29,17 @@ summaryLength = 30
     name = "Brave Metaverse"
     url = "https://bravemetaverse.com/blog/"
     weight = 4
+
+[security]
+  enableInlineShortcodes = false
+
+  [security.exec]
+    allow = ['^dart-sass-embedded$', '^go$', '^npx$', '^postcss$']
+    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM)$']
+
+  [security.funcs]
+    getenv = ['^HUGO_', 'CONTEXT']
+
+  [security.http]
+    methods = ['(?i)GET|POST']
+    urls = ['.*']


### PR DESCRIPTION
"CONTEXT" is not whitelisted in policy "security.funcs.getenv"